### PR TITLE
fix: Crash when accessign product configurable and display out of sto…

### DIFF
--- a/InventoryConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
+++ b/InventoryConfigurableProduct/Model/ResourceModel/Product/StockStatusBaseSelectProcessor.php
@@ -90,7 +90,7 @@ class StockStatusBaseSelectProcessor implements BaseSelectProcessorInterface
      */
     public function process(Select $select)
     {
-        if (!$this->stockConfig->isShowOutOfStock()) {
+        if ($this->stockConfig->isShowOutOfStock()) {
             $websiteCode = $this->storeManager->getWebsite()->getCode();
             $stock = $this->stockResolver->execute(SalesChannelInterface::TYPE_WEBSITE, $websiteCode);
             $stockId = (int)$stock->getStockId();


### PR DESCRIPTION
### Description (*)
When creating a configurable product and trying to access it get an error.

Exception #0 (Zend_Db_Select_Exception): You cannot define a correlation name 'stock' more than once

### Fixed Issues (if relevant)

1. Fixes mage-os/inventory#2: Fix: Configurable lowest price calculation when child products are out of stock #2
[https://github.com/mage-os/mageos-inventory/pull/2](url)

2. Revert mage-os/inventory#6: Revert [https://github.com/mage-os/mageos-inventory/pull/7](url)

### Manual testing scenarios (*)
On a fresh install of mage-os 1.1, create a configurable and access it on front basic.

1. Create configurable product.
2. Catalog -> Inventory -> Display out of stock -> No
3. Access on frontend

### Questions or comments
The issue solved by melindash looks to have introduced a new error.
The logic behind the select look to include the stock on 2 différents part of the code. Changing the behavior seems to have break the other side.

This change seem to have solved the issue.

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
